### PR TITLE
allows memoization of circular structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 npm-debug.log
 .DS_Store
 coverage/
+.vscode

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -144,3 +144,21 @@ test('inject custom serializer', function () {
 
   expect(serializerMethodExecutionCount).toBe(2)
 })
+
+test('memoize circular JSON', function () {
+  var circular = {
+    a: 'foo'
+  }
+  circular.b = circular
+
+  function circularFunction(a) {
+    return a.a
+  }
+
+  var memoizedCircularFunction = memoize(circularFunction)
+
+  // Assertions
+
+  expect(memoizedCircularFunction(circular)).toBe("foo")
+  expect(memoizedCircularFunction(circular)).toBe("foo")
+})


### PR DESCRIPTION
allows memoization of circular structures 

test('memoize circular JSON', function () {
  var circular = {
    a: 'foo'
  }
  circular.b = circular

  function circularFunction(a) {
    return a.a
  }

  var memoizedCircularFunction = memoize(circularFunction)

  // Assertions

  expect(memoizedCircularFunction(circular)).toBe("foo")
  expect(memoizedCircularFunction(circular)).toBe("foo")
})
