### PR TITLE
Remove inverted lookup and return on cache set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,25 +48,25 @@ function strategyDefault (fn, options) {
       cacheKey = serializer(arg)
     }
 
-    if (!cache.has(cacheKey)) {
-      var computedValue = fn.call(this, arg)
-      cache.set(cacheKey, computedValue)
-      return computedValue
+    if (cache.has(cacheKey)) {
+      return cache.get(cacheKey)
     }
 
-    return cache.get(cacheKey)
+    var computedValue = fn.call(this, arg)
+    cache.set(cacheKey, computedValue)
+    return computedValue
   }
 
   function variadic (fn, cache, serializer, ...args) {
     var cacheKey = serializer(args)
 
-    if (!cache.has(cacheKey)) {
-      var computedValue = fn.apply(this, args)
-      cache.set(cacheKey, computedValue)
-      return computedValue
+    if (cache.has(cacheKey)) {
+      return cache.get(cacheKey)
     }
 
-    return cache.get(cacheKey)
+    var computedValue = fn.apply(this, args)
+    cache.set(cacheKey, computedValue)
+    return computedValue
   }
 
   var memoized = fn.length === 1

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ class ObjectWithoutPrototypeCache {
   }
 
   set (key, value) {
-    this.cache[key] = value
+    return this.cache[key] = value
   }
 
   delete (key) {

--- a/src/index.js
+++ b/src/index.js
@@ -52,9 +52,7 @@ function strategyDefault (fn, options) {
       return cache.get(cacheKey)
     }
 
-    var computedValue = fn.call(this, arg)
-    cache.set(cacheKey, computedValue)
-    return computedValue
+    return cache.set(cacheKey, fn.call(this, arg))
   }
 
   function variadic (fn, cache, serializer, ...args) {
@@ -64,9 +62,7 @@ function strategyDefault (fn, options) {
       return cache.get(cacheKey)
     }
 
-    var computedValue = fn.apply(this, args)
-    cache.set(cacheKey, computedValue)
-    return computedValue
+    return cache.set(cacheKey, fn.apply(this, args))
   }
 
   var memoized = fn.length === 1


### PR DESCRIPTION
A couple of small optimisations:
- Invert the cache lookup, to avoid an extra logical operation
- Return on set cache
- Use that `return` to give the computed value back

|Before|After|
|:-:|:-:|
|![image](https://cloud.githubusercontent.com/assets/385232/22369705/7f81666e-e485-11e6-82b2-bae1549ee210.png)|![image](https://cloud.githubusercontent.com/assets/385232/22369723/8ce51f08-e485-11e6-8e69-15a3a180682b.png)|
