### PR TITLE
Fixes misleading custom cache docs description

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,20 @@ pass a custom cache to be used.
 
 ```js
 const memoized = memoize(fn, {
-  cache: customCache
+  cache: {
+    create() {
+      var store = {};
+      return {
+        has(key) { return (key in store); },
+        get(key) { return store[key]; },
+        set(key, value) { store[key] = value; }
+      };
+    }
+  }
 })
 ```
 
-The custom cache must implement the following methods:
+The custom cache should be an object containing a `create` method that returns an object implementing the following methods:
 - `get`
 - `set`
 - `has`


### PR DESCRIPTION
I found this out while trying to implement a custom cache to help me debugging my app.

I'll left for you to judge wether adding a working example for the custom cache is a good idea or not, anyways I still think the phrase should be more detailed as I had to read through the code in order to implement my custom cache 😊 