### PR TITLE
moving `monadic(..)` / `variadic(..)` out of `strategy(..)`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,31 +28,31 @@ module.exports = function memoize (fn, options) {
 const isPrimitive = (value) =>
   value == null || (typeof value !== 'function' && typeof value !== 'object')
 
+function monadic (fn, cache, serializer, arg) {
+  const cacheKey = isPrimitive(arg) ? arg : serializer(arg)
+
+  if (!cache.has(cacheKey)) {
+    const computedValue = fn.call(this, arg)
+    cache.set(cacheKey, computedValue)
+    return computedValue
+  }
+
+  return cache.get(cacheKey)
+}
+
+function variadic (fn, cache, serializer, ...args) {
+  const cacheKey = serializer(args)
+
+  if (!cache.has(cacheKey)) {
+    const computedValue = fn.apply(this, args)
+    cache.set(cacheKey, computedValue)
+    return computedValue
+  }
+
+  return cache.get(cacheKey)
+}
+
 function strategyDefault (fn, options) {
-  function monadic (fn, cache, serializer, arg) {
-    const cacheKey = isPrimitive(arg) ? arg : serializer(arg)
-
-    if (!cache.has(cacheKey)) {
-      const computedValue = fn.call(this, arg)
-      cache.set(cacheKey, computedValue)
-      return computedValue
-    }
-
-    return cache.get(cacheKey)
-  }
-
-  function variadic (fn, cache, serializer, ...args) {
-    const cacheKey = serializer(args)
-
-    if (!cache.has(cacheKey)) {
-      const computedValue = fn.apply(this, args)
-      cache.set(cacheKey, computedValue)
-      return computedValue
-    }
-
-    return cache.get(cacheKey)
-  }
-
   let memoized = fn.length === 1 ? monadic : variadic
 
   memoized = memoized.bind(


### PR DESCRIPTION
There doesn't appear to be any reason that `monadic(..)` and `variadic(..)` are nested inside of `strategy(..)`, as you're not relying on the closure but instead using `bind(..)`. I moved them out to slightly simplify.

I didn't notice any particular change in the benchmark from doing so (which a little surprised me), but then again, benchmarks like this only check CPU usage and not memory. It stands to reason those inner functions were getting recreated each time (unless maybe V8 is inlining them somehow) when inside `strategy(..)`, but now they should not need to be recreated.

Worst case is this is no benefit because of some already-advanced v8 optimization, but my intuition is it might be slightly better on overall performance (when you factory in memory churn).