### PR TITLE
Compiles es2015 to es5, and provides umd version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,28 @@
+{
+	"presets": [
+		"es2015",
+	],
+	"env": {
+		"umd": {
+			"plugins": [
+				["transform-es2015-modules-umd", {
+					"globals": {
+						"index": "fastMemoize"
+					},
+					"exactGlobals": true
+				}]
+			],
+		},
+		"min": {
+			"presets": ["babili"],
+			"plugins": [
+				["transform-es2015-modules-umd", {
+					"globals": {
+						"index": "fastMemoize"
+					},
+					"exactGlobals": true
+				}]
+			],
+		},
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 npm-debug.log
 .DS_Store
 coverage/
+lib/
+dist/

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.2.1",
   "description": "Fastest memoization lib that supports N arguments",
   "main": "src/index.js",
+  "browser": "lib/index.js",
   "scripts": {
     "benchmark": "node benchmark",
     "benchmark:cache": "node benchmark/cache",
@@ -15,6 +16,11 @@
     "benchmark:trace": "node --trace-inlining --trace-opt --trace-deopt benchmark/trace.js",
     "benchmark:v8-optimization-analysis": "node --allow_natives_syntax --expose_debug_as=VirtualMachine benchmark/v8-optimization-analysis.js",
     "benchmark:compare": "./benchmark/compare-commits/index.sh",
+    "prebuild": "rimraf lib dist && mkdirp lib dist",
+    "build:cjs": "babel src/index.js -o lib/index.js",
+    "build:umd": "cross-env BABEL_ENV=umd babel src/index.js -o dist/fast-memoize.js",
+    "build:min": "cross-env BABEL_ENV=min babel src/index.js -o dist/fast-memoize.min.js",
+    "build": "npm run build:cjs && npm run build:umd && npm run build:min",
     "lint": "eslint --fix \"src/**/*.js\" \"test/**/*.js\" \"benchmark/**/*.js\"",
     "preversion": "npm run test:all",
     "test": "jest",
@@ -23,6 +29,8 @@
   },
   "files": [
     "README.md",
+    "dist/",
+    "lib/",
     "src/"
   ],
   "repository": {
@@ -36,9 +44,14 @@
   },
   "homepage": "https://github.com/caiogondim/fast-memoize#readme",
   "devDependencies": {
+    "babel-cli": "^6.24.0",
+    "babel-plugin-transform-es2015-modules-umd": "^6.24.0",
+    "babel-preset-babili": "0.0.12",
+    "babel-preset-es2015": "^6.24.0",
     "benchmark": "^2.0.0",
     "cli-table2": "^0.2.0",
     "covert": "^1.1.0",
+    "cross-env": "^3.2.4",
     "eslint": "^3.12.1",
     "eslint-config-standard": "^6.2.1",
     "eslint-plugin-promise": "^3.4.0",
@@ -49,8 +62,10 @@
     "logdown": "^1.2.5",
     "lru-cache": "^4.0.0",
     "memoizee": "^0.4.1",
+    "mkdirp": "^0.5.1",
     "ora": "^0.3.0",
     "ramda": "^0.22.1",
+    "rimraf": "^2.6.1",
     "underscore": "^1.8.3"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:min": "cross-env BABEL_ENV=min babel src/index.js -o dist/fast-memoize.min.js",
     "build": "npm run build:cjs && npm run build:umd && npm run build:min",
     "lint": "eslint --fix \"src/**/*.js\" \"test/**/*.js\" \"benchmark/**/*.js\"",
-    "preversion": "npm run test:all",
+    "preversion": "npm run build && npm run test:all",
     "test": "jest",
     "test:all": "npm run lint && npm run test",
     "test:coverage": "covert test/*.js"


### PR DESCRIPTION
The src module is not friendly to old version browsers and uglify.js. So it'd be great to use Babel to compile es2015 before publishing on npm.

Related issues:

- https://github.com/caiogondim/fast-memoize.js/issues/31
- https://github.com/caiogondim/fast-memoize.js/issues/34