### PR TITLE
Monadic strategy is misleading / error-prone (spread arguments)

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,21 @@ test('memoize functions with N arguments', () => {
   expect(memoizedNToThePower(2, 3)).toBe(8)
 })
 
+test('memoize functions with spread arguments', () => {
+  function multiply (multiplier, ...theArgs) {
+    return theArgs.map(function (element) {
+      return multiplier * element
+    })
+  }
+
+  const memoizedMultiply = memoize(multiply)
+
+  // Assertions
+
+  expect(memoizedMultiply(2, 1, 2, 3)).toEqual([2, 4, 6])
+  expect(memoizedMultiply(2, 4, 5, 6)).toEqual([8, 10, 12])
+})
+
 test('inject custom cache', () => {
   let hasMethodExecutionCount = 0
   let setMethodExecutionCount = 0


### PR DESCRIPTION
This pull request seeks to surface an issue with the "monadic" strategy. I appreciated [your blog post](https://community.risingstack.com/the-worlds-fastest-javascript-memoization-library/) on creating `fast-memoize.js`, but the optimization strategy leveraging `fn.length` seemed problematic to me, particularly for functions accepting [spread / rest arguments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters).

Included is a failing test case demonstrating the issue. The code example is pulled directly from [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters#Examples) (public domain licensed), and fails to return a correct result.

Specifically, given the function:

```js
function multiply (multiplier, ...theArgs) {
  return theArgs.map(function (element) {
    return multiplier * element
  })
}
```

The value of `multiply.length` is `1`, but this is not enough to conclude the function expects a single argument, because of spread arguments.

The current implementation will return an empty array because it only passes the first multiplier argument to the original function. Even if it were to pass all arguments, using the first argument as a cache key would cause incorrect caching on differing spread arguments.

A workaround may be to document the fact that memoizing a function accepting spread arguments should specify a strategy. Ideally the variadic strategy would be exported to simplify this alternative.