### PR TITLE
Improve TypeScript definitions

### DIFF
--- a/typings/fast-memoize.d.ts
+++ b/typings/fast-memoize.d.ts
@@ -6,11 +6,11 @@ export interface Cache<K, V> {
   has(key: K): boolean;
 }
 
-export type Serializer = (args: any[]) => string;
+export type Serializer<F extends Func> = (args: Parameters<F>) => string;
 
 export interface Options<F extends Func> {
   cache?: Cache<string, ReturnType<F>>;
-  serializer?: Serializer;
+  serializer?: Serializer<F>;
   strategy?: MemoizeFunc;
 }
 


### PR DESCRIPTION
With this change, typings for arguments in `serializer` option can be inferred automatically from the first param:

<img width="605" alt="Screen Shot 2019-07-06 at 21 18 52" src="https://user-images.githubusercontent.com/10968765/60758024-ce835300-a033-11e9-8c77-db9b2368f3d0.png">
