### PR TITLE
fix(typing): serializer type signature fixed

### DIFF
--- a/typings/fast-memoize.d.ts
+++ b/typings/fast-memoize.d.ts
@@ -6,11 +6,13 @@ export interface Cache<K, V> {
   has(key: K): boolean;
 }
 
-export type Serializer = (args: any[]) => string;
+export interface Serializer<Args> {
+  (args: Args): string;
+}
 
 export interface Options<F extends Func> {
   cache?: Cache<string, ReturnType<F>>;
-  serializer?: Serializer;
+  serializer?: Serializer<Parameters<F>>;
   strategy?: MemoizeFunc;
 }
 


### PR DESCRIPTION
* `Serializer` signature now infer from the input function parameters.